### PR TITLE
Add accurateRip feature

### DIFF
--- a/lib/rubyripper/accurateRip.rb
+++ b/lib/rubyripper/accurateRip.rb
@@ -1,0 +1,427 @@
+#!/usr/bin/env ruby
+#    Rubyripper - A secure ripper for Linux/BSD/OSX
+#    Copyright (C) 2007 - 2010  Bouke Woudstra (boukewoudstra@gmail.com)
+#
+#    This file is part of Rubyripper. Rubyripper is free software: you can
+#    redistribute it and/or modify it under the terms of the GNU General
+#    Public License as published by the Free Software Foundation, either
+#    version 3 of the License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+require 'net/http'
+require 'uri'
+require 'tempfile'
+require 'rubyripper/modules/audioCalculations'
+require 'rubyripper/preferences/main'
+
+# Class to hold the verification results of AccurateRip
+class AccurateRipResult
+  include AudioCalculations
+
+  attr_reader :status,           # true if all tracks matched
+              :computed_v1,      # {track_number => crc}
+              :computed_v2,      # {track_number => crc}
+              :pressings,        # Array of multiple pressing data
+              :track_results     # {track_number => {matched: bool, version: :v1/:v2, pressing_index: int, confidence: int}}
+
+  def initialize
+    @status = false
+    @computed_v1 = {}
+    @computed_v2 = {}
+    @pressings = []
+    @track_results = {}
+  end
+
+  # Set CRC calculated locally
+  def setComputedChecksums(track, v1_crc, v2_crc)
+    @computed_v1[track] = v1_crc
+    @computed_v2[track] = v2_crc
+  end
+
+  # Add remote pressing data
+  def addPressing(pressing_data)
+    @pressings << pressing_data
+  end
+
+  # Set verification result per track
+  def setTrackResult(track, matched, version, pressing_index, confidence)
+    @track_results[track] = {
+      matched: matched,
+      version: version,
+      pressing_index: pressing_index,
+      confidence: confidence
+    }
+  end
+
+  # Check if all tracks matched
+  def finalize
+    @status = @track_results.values.all? { |r| r[:matched] }
+  end
+
+  # Generate string for logging (table format)
+  def toStr
+    lines = []
+    lines << "AccurateRip verification results:"
+
+    if @pressings.empty?
+      lines << "  No entry found in the database"
+      return lines.join("\n")
+    end
+
+    lines << "  #{@pressings.size} pressing(s) found in the database"
+    lines << ""
+
+    # Table header
+    lines << "     Track |  V1 CRC  |  V2 CRC  |   Result   | DB"
+    lines << "    -------+----------+----------+------------+------------------------------------------"
+
+    # Track results
+    @computed_v1.keys.sort.each do |track|
+      result = @track_results[track]
+      v1_crc = format('%08X', @computed_v1[track])
+      v2_crc = format('%08X', @computed_v2[track])
+
+      # Result column
+      if result && result[:matched]
+        result_str = "Matched"
+      else
+        result_str = "Unmatched"
+      end
+
+      # DB column: list CRCs and confidence for all pressings
+      db_entries = []
+      @pressings.each do |pressing|
+        track_data = pressing[:tracks][track]
+        if track_data && track_data[:crc] != 0
+          crc_str = format('%08X', track_data[:crc])
+          db_entries << "#{crc_str}(#{track_data[:confidence]})"
+        end
+      end
+      db_str = db_entries.empty? ? "-" : db_entries.join(", ")
+
+      lines << format("       %2d  | %s | %s | %9s  | %s", 
+                      track, v1_crc, v2_crc, result_str, db_str)
+    end
+
+    lines << ""
+    lines << " #{@status ? 'All tracks verified successfully' : 'Some tracks did not match'}"
+
+    lines.join("\n")
+  end
+end
+
+# Class to perform CD verification using AccurateRip
+class AccurateRip
+  include AudioCalculations
+
+  SECTOR_BYTES = 2352
+  SKIP_SECTORS = 5
+
+  def initialize(disc, prefs = nil)
+    @disc = disc
+    @prefs = prefs || Preferences::Main.instance
+    @disc_ident = nil
+  end
+
+  # Verify multiple tracks and return AccurateRipResult (track mode)
+  # files: hash map of {track_number => file_path}
+  def verifyTracks(files)
+    result = AccurateRipResult.new
+    prepareVerification(result)
+
+    files.each do |track, file_path|
+      audio_data = readAudioData(file_path)
+      next unless audio_data
+      verifyTrackData(track, audio_data, result)
+    end
+
+    result.finalize
+    result
+  end
+
+  # Verify image file and return AccurateRipResult (image mode)
+  # file_path: path to the image file
+  def verifyImage(file_path)
+    result = AccurateRipResult.new
+    prepareVerification(result)
+
+    audio_data = readAudioData(file_path)
+    return result unless audio_data
+
+    track_count = @disc.audiotracks
+    (1..track_count).each do |track|
+      track_audio_data = extractTrackFromImage(audio_data, track)
+      next unless track_audio_data
+      verifyTrackData(track, track_audio_data, result)
+    end
+
+    result.finalize
+    result
+  end
+
+  private
+
+  # Prepare for verification (build Disc Ident and fetch database)
+  def prepareVerification(result)
+    buildDiscIdent
+
+    bin_path = fetchAccurateRipFile
+    if bin_path
+      parseAccurateRipData(bin_path, result)
+      File.delete(bin_path) if File.exist?(bin_path)
+    end
+  end
+
+  # Verify audio data of a single track
+  def verifyTrackData(track, audio_data, result)
+    v1_crc = computeV1Checksum(track, audio_data)
+    v2_crc = computeV2Checksum(track, audio_data)
+
+    result.setComputedChecksums(track, v1_crc, v2_crc)
+    matchTrackWithPressings(track, v1_crc, v2_crc, result)
+  end
+
+  # Compare track with pressing data
+  def matchTrackWithPressings(track, v1_crc, v2_crc, result)
+    matched = false
+    result.pressings.each_with_index do |pressing, idx|
+      track_data = pressing[:tracks][track]
+      next unless track_data
+
+      if track_data[:crc] == v2_crc
+        result.setTrackResult(track, true, :v2, idx, track_data[:confidence])
+        matched = true
+        break
+      elsif track_data[:crc] == v1_crc
+        result.setTrackResult(track, true, :v1, idx, track_data[:confidence])
+        matched = true
+        break
+      end
+    end
+
+    result.setTrackResult(track, false, nil, nil, nil) unless matched
+  end
+
+  # Extract audio data of a specific track from the image file
+  def extractTrackFromImage(image_audio_data, track)
+    # Get start sector and length of the track
+    # Calculate relative position within the image (relative to track 1)
+    first_track_start = @disc.getStartSector(1)
+    track_start = @disc.getStartSector(track)
+    track_length = @disc.getLengthSector(track)
+
+    # Byte offset within the image
+    relative_start = track_start - first_track_start
+    byte_offset = relative_start * SECTOR_BYTES
+    byte_length = track_length * SECTOR_BYTES
+
+    # Range check
+    return nil if byte_offset < 0
+    return nil if byte_offset + byte_length > image_audio_data.size
+
+    # Extract data
+    image_audio_data[byte_offset, byte_length]
+  end
+
+  # Build Disc Identifier
+  def buildDiscIdent
+    track_count = @disc.audiotracks
+    track_offsets_added = 0
+    track_offsets_multiplied = 0
+
+    # Collect start LBA of each track
+    offsets = []
+    (1..track_count).each do |track|
+      lba = @disc.getStartSector(track)
+      offsets << lba
+      track_offsets_added += lba
+      lba = 1 if lba == 0  # Calculate as 1 if it is 0
+      track_offsets_multiplied += lba * track
+    end
+
+    # Also add end position of the last track
+    last_track_end = @disc.getStartSector(track_count) + @disc.getLengthSector(track_count)
+    offsets << last_track_end
+    track_offsets_added += last_track_end
+    last_track_end = 1 if last_track_end == 0
+    track_offsets_multiplied += last_track_end * (track_count + 1)
+
+    # Get FreeDB ID
+    freedb_id = @disc.freedbDiscid.to_i(16) rescue 0
+
+    @disc_ident = {
+      track_count: track_count,
+      track_offsets_added: track_offsets_added & 0xFFFFFFFF,
+      track_offsets_multiplied: track_offsets_multiplied & 0xFFFFFFFF,
+      freedb_id: freedb_id & 0xFFFFFFFF
+    }
+  end
+
+  # Download bin file from AccurateRip database
+  def fetchAccurateRipFile
+    return nil unless @disc_ident
+
+    track_offsets_added_hex = format('%08x', @disc_ident[:track_offsets_added])
+    url_path = "/accuraterip/#{track_offsets_added_hex[7]}/#{track_offsets_added_hex[6]}/#{track_offsets_added_hex[5]}/" \
+               "dBAR-#{format('%03d', @disc_ident[:track_count])}-" \
+               "#{format('%08x', @disc_ident[:track_offsets_added])}-" \
+               "#{format('%08x', @disc_ident[:track_offsets_multiplied])}-" \
+               "#{format('%08x', @disc_ident[:freedb_id])}.bin"
+
+    uri = URI.parse("http://www.accuraterip.com#{url_path}")
+
+    begin
+      response = Net::HTTP.get_response(uri)
+      if response.code == '200'
+        temp_file = Tempfile.new(['accuraterip', '.bin'])
+        temp_file.binmode
+        temp_file.write(response.body)
+        temp_file.close
+        return temp_file.path
+      else
+        puts "AccurateRip: Could not get data from database (HTTP #{response.code})" if @prefs.debug
+        return nil
+      end
+    rescue StandardError => e
+      puts "AccurateRip: Network error: #{e.message}" if @prefs.debug
+      return nil
+    end
+  end
+
+  # Parse bin file and add pressing data to result
+  # Structure:
+  #   STAcRipDiscIdent (13 bytes):
+  #     - TrackCount: 1 byte
+  #     - TrackOffsetsAdded: 4 bytes (little endian)
+  #     - TrackOffsetsMultiplied: 4 bytes (little endian)
+  #     - FreedBIdent: 4 bytes (little endian)
+  #   STAcRipATrack (9 bytes x track_count):
+  #     - Confidence: 1 byte
+  #     - TrackCRC: 4 bytes (little endian)
+  #     - OffsetFindCRC: 4 bytes (little endian)
+  def parseAccurateRipData(file_path, result)
+    File.open(file_path, 'rb') do |f|
+      until f.eof?
+        # Load DiscIdent (13 bytes)
+        ident_data = f.read(13)
+        break if ident_data.nil? || ident_data.size < 13
+
+        track_count = ident_data[0].ord
+        # track_offsets_added = ident_data[1..4].unpack1('V')
+        # track_offsets_multiplied = ident_data[5..8].unpack1('V')
+        # freedb_id = ident_data[9..12].unpack1('V')
+
+        pressing = { tracks: {} }
+
+        # Load data of each track (9 bytes x track_count)
+        track_count.times do |i|
+          track_data = f.read(9)
+          break if track_data.nil? || track_data.size < 9
+
+          confidence = track_data[0].ord
+          track_crc = track_data[1..4].unpack1('V')
+          # offset_find_crc = track_data[5..8].unpack1('V')  # Not used
+
+          pressing[:tracks][i + 1] = {
+            confidence: confidence,
+            crc: track_crc
+          }
+        end
+
+        result.addPressing(pressing)
+      end
+    end
+  end
+
+  # Load audio data from WAV file
+  def readAudioData(file_path)
+    return nil unless File.exist?(file_path)
+
+    File.open(file_path, 'rb') do |f|
+      f.seek(BYTES_WAV_CONTAINER)  # Skip WAV header
+      f.read
+    end
+  end
+
+  # Calculate AccurateRip V1 CRC
+  def computeV1Checksum(track, audio_data)
+    data_size = audio_data.size
+    dword_count = data_size / 4
+
+    # Calculate skip range
+    skip_from = 0
+    skip_to = dword_count
+
+    # Skip the first 5 sectors of the first track
+    if track == 1
+      skip_from = (SECTOR_BYTES * SKIP_SECTORS) / 4
+    end
+
+    # Skip the last 5 sectors of the last track
+    if track == @disc.audiotracks
+      skip_to -= (SECTOR_BYTES * SKIP_SECTORS) / 4
+    end
+
+    crc = 0
+    pos = 1
+
+    dword_count.times do |i|
+      if pos >= skip_from && pos <= skip_to
+        # Load 4 bytes as little endian
+        sample = audio_data[i * 4, 4].unpack1('V')
+        crc += pos * sample
+        crc &= 0xFFFFFFFF  # Limit to 32bit
+      end
+      pos += 1
+    end
+
+    crc
+  end
+
+  # Calculate AccurateRip V2 CRC
+  def computeV2Checksum(track, audio_data)
+    data_size = audio_data.size
+    dword_count = data_size / 4
+
+    # Calculate skip range
+    skip_from = 0
+    skip_to = dword_count
+
+    # Skip the first 5 sectors of the first track
+    if track == 1
+      skip_from = (SECTOR_BYTES * SKIP_SECTORS) / 4
+    end
+
+    # Skip the last 5 sectors of the last track
+    if track == @disc.audiotracks
+      skip_to -= (SECTOR_BYTES * SKIP_SECTORS) / 4
+    end
+
+    crc = 0
+    pos = 1
+
+    dword_count.times do |i|
+      if pos >= skip_from && pos <= skip_to
+        sample = audio_data[i * 4, 4].unpack1('V')
+
+        # V2: multiply 64bit and add HI/LO
+        calc = pos * sample
+        lo = calc & 0xFFFFFFFF
+        hi = (calc >> 32) & 0xFFFFFFFF
+
+        crc += hi + lo
+        crc &= 0xFFFFFFFF
+      end
+      pos += 1
+    end
+
+    crc
+  end
+end

--- a/lib/rubyripper/accurateRip.rb
+++ b/lib/rubyripper/accurateRip.rb
@@ -404,10 +404,12 @@ class AccurateRip
     samples = audio_data.unpack('V*')
 
     crc = 0
-    (skip_from...skip_to).each do |i|
+    i = skip_from
+    while i < skip_to
       pos = i + 1
       crc += pos * samples[i]
       crc &= 0xFFFFFFFF
+      i += 1
     end
 
     crc
@@ -434,7 +436,8 @@ class AccurateRip
     samples = audio_data.unpack('V*')
 
     crc = 0
-    (skip_from...skip_to).each do |i|
+    i = skip_from
+    while i < skip_to
       pos = i + 1
       sample = samples[i]
 
@@ -445,6 +448,7 @@ class AccurateRip
 
       crc += hi + lo
       crc &= 0xFFFFFFFF
+      i += 1
     end
 
     crc

--- a/lib/rubyripper/cli/cliPreferences.rb
+++ b/lib/rubyripper/cli/cliPreferences.rb
@@ -145,8 +145,10 @@ private
     @out.puts ' 6) ' + _("Match erroneous chunks") + ": %s" % [@prefs.reqMatchesErrors]
     @out.puts ' 7) ' + _("Maximum trials") + ": %s" % [@prefs.maxTries == 0 ? "no\
  maximum" : @prefs.maxTries]
-    @out.puts ' 8) ' + _("Eject disc after ripping %s") % [showBool(@prefs.eject)]
-    @out.puts ' 9) ' + _("Only keep log when errors %s") % [showBool(@prefs.noLog)]
+    @out.puts ' 8) ' + _("AccurateRip verification %s") % [showBool(@prefs.accRip)]
+    @out.puts ' 9) ' + _("AccurateRip every trial (Finish early if verified successfully) %s") % [showBool(@prefs.accRipEveryTime)]
+    @out.puts '10) ' + _("Eject disc after ripping %s") % [showBool(@prefs.eject)]
+    @out.puts '11) ' + _("Only keep log when errors %s") % [showBool(@prefs.noLog)]
     @out.puts '99) ' + _("Back to settings main menu")
     @out.puts ""
     @int.get("Please type the number of the setting you wish to change", 99)
@@ -165,8 +167,10 @@ private
       when 5 then @prefs.reqMatchesAll = @int.get(_("Match all chunks"), 2)
       when 6 then @prefs.reqMatchesErrors = @int.get(_("Match erronous chunks"), 3)
       when 7 then @prefs.maxTries = @int.get(_("Maximum trials"), 5)
-      when 8 then switchBool('eject')
-      when 9 then switchBool('noLog')
+      when 8 then switchBool('accRip')
+      when 9 then switchBool('accRipEveryTime')
+      when 10 then switchBool('eject')
+      when 11 then switchBool('noLog')
     else noValidChoiceMessage(choice)
     end
     loopSubMenuRipping() unless choice == 99

--- a/lib/rubyripper/gtk3/gtkPreferences.rb
+++ b/lib/rubyripper/gtk3/gtkPreferences.rb
@@ -99,6 +99,8 @@ class GtkPreferences
     @allChunksSpin.value = @prefs.reqMatchesAll.to_f
     @errChunksSpin.value = @prefs.reqMatchesErrors.to_f
     @maxSpin.value = @prefs.maxTries.to_f
+    @accRip.active = @prefs.accRip
+    @accRipEveryTime.active = @prefs.accRipEveryTime
     @ripEntry.text = @prefs.rippersettings
     @eject.active = @prefs.eject
     @noLog.active = @prefs.noLog
@@ -166,6 +168,8 @@ class GtkPreferences
     @prefs.reqMatchesAll = @allChunksSpin.value.to_i
     @prefs.reqMatchesErrors = @errChunksSpin.value.to_i
     @prefs.maxTries = @maxSpin.value.to_i
+    @prefs.accRip = @accRip.active?
+    @prefs.accRipEveryTime = @accRipEveryTime.active?
     @prefs.rippersettings = @ripEntry.text
     @prefs.eject = @eject.active?
     @prefs.noLog = @noLog.active?
@@ -288,11 +292,13 @@ It is recommended to enable this option.")
 
   # 2nd frame on secure ripping tab
   def buildFrameRippingOptions
-    @table50 = newTable(rows=3, columns=3)
+    @table50 = newTable(rows=5, columns=3)
 #create objects
     @all_chunks = Gtk::Label.new(_("Match all chunks:")) ; @all_chunks.set_alignment(0.0, 0.5)
     @err_chunks = Gtk::Label.new(_("Match erroneous chunks:")) ; @err_chunks.set_alignment(0.0, 0.5)
     @max_label = Gtk::Label.new(_("Maximum trials (0 = unlimited):")) ; @max_label.set_alignment(0.0, 0.5)
+    @accRip = Gtk::CheckButton.new(_("AccurateRip verification"))
+    @accRipEveryTime = Gtk::CheckButton.new(_("AccurateRip every trial (finish early on match)"))
     @allChunksSpin = Gtk::SpinButton.new(2.0,  100.0, 1.0)
     @errChunksSpin = Gtk::SpinButton.new(2.0, 100.0, 1.0)
     @maxSpin = Gtk::SpinButton.new(0.0, 100.0, 1.0)
@@ -303,6 +309,9 @@ It is recommended to enable this option.")
     @table50.attach(@all_chunks, 0, 1, 0, 1, Gtk::AttachOptions::FILL, Gtk::AttachOptions::SHRINK, 0, 0) #1st column
     @table50.attach(@err_chunks, 0, 1, 1, 2, Gtk::AttachOptions::FILL, Gtk::AttachOptions::SHRINK, 0, 0)
     @table50.attach(@max_label, 0, 1, 2, 3, Gtk::AttachOptions::FILL, Gtk::AttachOptions::SHRINK, 0, 0)
+    @table50.attach(@accRip, 0, 3, 3, 4, Gtk::AttachOptions::FILL, Gtk::AttachOptions::SHRINK, 0, 0)
+    @table50.attach(@accRipEveryTime, 0, 3, 4, 5, Gtk::AttachOptions::FILL, Gtk::AttachOptions::SHRINK, 0, 0)
+    
     @table50.attach(@allChunksSpin, 1, 2, 0, 1, Gtk::AttachOptions::FILL, Gtk::AttachOptions::SHRINK, 0, 0) #2nd column
     @table50.attach(@errChunksSpin, 1, 2, 1, 2, Gtk::AttachOptions::FILL, Gtk::AttachOptions::SHRINK, 0, 0)
     @table50.attach(@maxSpin, 1, 2, 2, 3, Gtk::AttachOptions::FILL, Gtk::AttachOptions::SHRINK, 0, 0)
@@ -311,6 +320,7 @@ It is recommended to enable this option.")
     @table50.attach(@time3, 2, 3, 2, 3, Gtk::AttachOptions::FILL, Gtk::AttachOptions::SHRINK, 0, 0)
 #connect a signal to @all_chunks to make sure @err_chunks get always at least the same amount of rips as @all_chunks
     @allChunksSpin.signal_connect("value_changed") {if @errChunksSpin.value < @allChunksSpin.value ; @errChunksSpin.value = @allChunksSpin.value end ; @errChunksSpin.set_range(@allChunksSpin.value,100.0)} #ensure all_chunks cannot be smaller that err_chunks.
+    @accRip.signal_connect("clicked") {@accRipEveryTime.sensitive = @accRip.active?}
     @frame50= newFrame(_('Ripping options'), child=@table50)
   end
 

--- a/lib/rubyripper/log.rb
+++ b/lib/rubyripper/log.rb
@@ -193,6 +193,16 @@ class Log
     add("     " + _("Copy MD5: %s\n\n") % [md5sum])
   end
 
+  # Output AccurateRip verification results to log
+  def accurateRipResult(result)
+    add("\n")
+    add("=" * 60 + "\n")
+    add(result.toStr + "\n")
+    add("=" * 60 + "\n")
+    add("\n")
+  end
+
+
   def summary() #Give an overview of errors
     if @encodingErrors ; @short_summary += _("\nWARNING: ENCODING ERRORS WERE DETECTED\n") ; end
     @short_summary += _("\nRIPPING SUMMARY\n\n")

--- a/lib/rubyripper/preferences/data.rb
+++ b/lib/rubyripper/preferences/data.rb
@@ -62,6 +62,14 @@ module Preferences
     # Throw away the log if no errors are found
     attr_accessor :noLog
 
+    # ACCURATE RIP PREFERENCES
+    # Enable AccurateRip verification
+    attr_accessor :accRip
+
+    # If true, perform AccurateRip verification after each trial
+    # and finish early when all tracks match.
+    attr_accessor :accRipEveryTime
+
     # TOC ANALYSIS PREFERENCES
     # Create a cuesheet
     attr_accessor :createCue

--- a/lib/rubyripper/preferences/setDefaults.rb
+++ b/lib/rubyripper/preferences/setDefaults.rb
@@ -45,6 +45,8 @@ module Preferences
       @data.maxTries = 7
       @data.eject = true
       @data.noLog = false
+      @data.accRip = false
+      @data.accRipEveryTime = false
     end
 
     def setTocAnalysisDefaults

--- a/lib/rubyripper/secureRip.rb
+++ b/lib/rubyripper/secureRip.rb
@@ -69,7 +69,12 @@ class SecureRip
     ripTrack()
     restoreParanoiaSettings()
     
-    performAccurateRipVerification() unless @cancelled || @rippedFiles.empty?
+    
+    # performAccurateRipVerification() unless @cancelled || @rippedFiles.empty?
+    # Only perform AccurateRip verification once at the end when accRipEveryTime=false
+    if @prefs.accRip && !@prefs.accRipEveryTime && !@cancelled && !@rippedFiles.empty?
+      performAccurateRipVerification()
+    end
     
     startEncodingForTracks()
   end
@@ -83,7 +88,11 @@ class SecureRip
       restoreParanoiaSettings()
     end
     
-    performAccurateRipVerification() unless @cancelled || @rippedFiles.empty?
+    # performAccurateRipVerification() unless @cancelled || @rippedFiles.empty?
+    # Only perform AccurateRip verification once at the end when accRipEveryTime=false
+    if @prefs.accRip && !@prefs.accRipEveryTime && !@cancelled && !@rippedFiles.empty?
+      performAccurateRipVerification()
+    end
     
     startEncodingForTracks()
   end
@@ -166,7 +175,25 @@ is #{@disc.getFileSize(track)} bytes." if @prefs.debug
   end
 
   def main(track=nil)
-    @reqMatchesAll.times{if not doNewTrial(track) ; return false end} # The amount of matches all sectors should match
+    @reqMatchesAll.times do
+      if not doNewTrial(track) ; return false end
+      
+      # If accRipEveryTime is true, perform AccurateRip verification after each trial
+      if @prefs.accRip && @prefs.accRipEveryTime
+        ar_result = performAccurateRipVerification(track, @trial)
+        if ar_result && ar_result.status
+          # Success: keep this trial's file and finish early
+          cleanupOtherTrialFiles(track, @trial)
+          @crcs = [getCRC(track, 1)] # Recalculate CRC (for renamed file)
+          @log.finishTrack(@peakLevel, @crcs, _("Copy OK"), nil)
+          @log.copyMD5(@digest)
+          @log.updateRippingProgress(track)
+          return true
+        end
+      end
+    end 
+    # The amount of matches all sectors should match
+
     analyzeFiles(track) #If there are differences, save them in the @errors hash
     status = _("Copy OK")
 
@@ -191,6 +218,15 @@ is #{@disc.getFileSize(track)} bytes." if @prefs.debug
       # for example is trial = 3 and only 2 matches are required a match can happen
       correctErrorPos(track) if @trial > @reqMatchesErrors
       @correctedcrc = getCRC(track, 1)
+
+      # If accRipEveryTime is true, perform AccurateRip verification after error correction
+      if @prefs.accRip && @prefs.accRipEveryTime
+        ar_result = performAccurateRipVerification(track, 1)
+        if ar_result && ar_result.status
+          @errors.clear
+          break
+        end
+      end
     end
 
     @log.finishTrack(@peakLevel, @crcs, status, @correctedcrc)
@@ -458,25 +494,74 @@ is #{@disc.getFileSize(track)} bytes." if @prefs.debug
   end
 
   # Execute AccurateRip verification
-  def performAccurateRipVerification
+  #
+  # This method handles two main scenarios based on the arguments:
+  # 1. Verify all tracks
+  #    - Arguments: track=nil, trial=1 (default)
+  #    - Target: Uses @rippedFiles hash which contains all successfully ripped tracks.
+  #
+  # 2. Verify a single track (Early finish check)
+  #    - Arguments: track=Integer, trial=Integer
+  #    - Target: Uses specific temporary file for the given track and trial.
+  #
+  # In both scenarios, the behavior differs based on @prefs.image:
+  # - Image Mode (@prefs.image=true): Verifies a single image file using verifyImage(path).
+  # - Track Mode (@prefs.image=false): Verifies one or more tracks using verifyTracks(hash).
+  #
+  def performAccurateRipVerification(track=nil, trial=1)
     puts "DEBUG: Starting AccurateRip verification" if @prefs.debug
 
     begin
       accuraterip = AccurateRip.new(@disc, @prefs)
+      result = nil
 
-      # Change method to call depending on image mode or track mode
       if @prefs.image
-        file_path = @rippedFiles.values.first
+        # --- Image Mode ---
+        # Image mode always verifies a single file.
+        # getTempFile ignores track argument in image mode, so we always use it.
+        file_path = @fileScheme.getTempFile(track, trial)
+        
+        return nil unless file_path && File.exist?(file_path)
         result = accuraterip.verifyImage(file_path)
       else
-        result = accuraterip.verifyTracks(@rippedFiles)
+        # --- Track Mode ---
+        # Track mode verifies a hash of {track_number => file_path}.
+        if track.nil?
+          # Verify all ripped files (legacy behavior, called from ripImage/ripTracks after completion)
+          files_hash = @rippedFiles
+        else
+          # Verify single specific file (called from main method for early finish check)
+          path = @fileScheme.getTempFile(track, trial)
+          return nil unless path && File.exist?(path)
+          files_hash = {track => path}
+        end
+        
+        result = accuraterip.verifyTracks(files_hash)
       end
 
       # Output results to log (also displays on stdout via @log.add)
       @log.accurateRipResult(result)
+      result
     rescue StandardError => e
       puts "An error occurred during AccurateRip verification: #{e.message}" if @prefs.debug
       @log << "An error occurred during AccurateRip verification: #{e.message}\n"
+      nil
+    end
+  end
+
+  # Remove temporary files from other trials and rename the successful one to trial 1
+  def cleanupOtherTrialFiles(track, success_trial)
+    (1..@trial).each do |t|
+      next if t == success_trial
+      file = @fileScheme.getTempFile(track, t)
+      File.delete(file) if File.exist?(file)
+    end
+    
+    # Rename successful file to trial 1 location if needed
+    if success_trial != 1
+      success_file = @fileScheme.getTempFile(track, success_trial)
+      target_file = @fileScheme.getTempFile(track, 1)
+      FileUtils.mv(success_file, target_file)
     end
   end
 end

--- a/spec/accurateRip_parallel_spec.rb
+++ b/spec/accurateRip_parallel_spec.rb
@@ -1,0 +1,79 @@
+require 'rubyripper/accurateRip'
+require 'parallel'
+
+describe AccurateRipResult do
+  describe '#merge' do
+    it 'should merge results from another instance' do
+      result1 = AccurateRipResult.new
+      result1.setComputedChecksums(1, 0x111, 0x222)
+      result1.setTrackResult(1, true, :v1, 0, 10)
+
+      result2 = AccurateRipResult.new
+      result2.setComputedChecksums(2, 0x333, 0x444)
+      result2.setTrackResult(2, false, nil, nil, nil)
+
+      result1.merge(result2)
+
+      expect(result1.computed_v1[1]).to eq(0x111)
+      expect(result1.computed_v2[1]).to eq(0x222)
+      expect(result1.track_results[1][:matched]).to eq(true)
+
+      expect(result1.computed_v1[2]).to eq(0x333)
+      expect(result1.computed_v2[2]).to eq(0x444)
+      expect(result1.track_results[2][:matched]).to eq(false)
+    end
+  end
+end
+
+describe AccurateRip do
+  let(:disc) { double('Disc').as_null_object }
+  let(:prefs) { double('Preferences').as_null_object }
+  let(:ar) { AccurateRip.new(disc, prefs) }
+
+  before do
+    allow(Parallel).to receive(:processor_count).and_return(2)
+    # Silence stdout
+    allow($stdout).to receive(:write)
+  end
+
+  describe '#verifyTracks' do
+    it 'should use Parallel.map with in_processes' do
+      files = { 1 => 'track1.wav', 2 => 'track2.wav' }
+      
+      expect(Parallel).to receive(:map).with(files, hash_including(in_processes: 2)).and_call_original
+
+      # Mock reading audio data to avoid FS error and actually return verification
+      allow(ar).to receive(:readAudioData).and_return('dummy_audio_data')
+      # Mock prepareVerification to avoid net request
+      allow(ar).to receive(:prepareVerification)
+      
+      # Mock verifyTrackData to prevent errors
+      allow(ar).to receive(:verifyTrackData)
+
+      # We need to stub Parallel.map's block execution because rspec mock kills the yield if not careful? 
+      # Actually and_call_original executes it. 
+      # But inside the block, it creates new AccurateRipResult and calls methods.
+      # The block runs in a FORKED process. RSpec mocks might not carry over to forks easily.
+      # However, Parallel.map runs the block.
+      
+      # For simple verification that Parallel is called:
+      ar.verifyTracks(files)
+    end
+  end
+
+  describe '#verifyImage' do
+    it 'should use Parallel.map with in_processes' do
+      file_path = 'image.wav'
+      allow(disc).to receive(:audiotracks).and_return(2)
+      
+      expect(Parallel).to receive(:map).with(1..2, hash_including(in_processes: 2)).and_call_original
+
+      allow(ar).to receive(:readAudioData).and_return('dummy_large_audio_data')
+      allow(ar).to receive(:prepareVerification)
+      allow(ar).to receive(:extractTrackFromImage).and_return('dummy_track_data')
+      allow(ar).to receive(:verifyTrackData)
+
+      ar.verifyImage(file_path)
+    end
+  end
+end

--- a/spec/accurateRip_spec.rb
+++ b/spec/accurateRip_spec.rb
@@ -1,0 +1,197 @@
+#!/usr/bin/env ruby
+#    Rubyripper - A secure ripper for Linux/BSD/OSX
+#    Copyright (C) 2007 - 2010 Bouke Woudstra (boukewoudstra@gmail.com)
+#
+#    This file is part of Rubyripper. Rubyripper is free software: you can
+#    redistribute it and/or modify it under the terms of the GNU General
+#    Public License as published by the Free Software Foundation, either
+#    version 3 of the License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+require 'rubyripper/accurateRip'
+require 'tempfile'
+
+describe AccurateRipResult do
+  describe '#initialize' do
+    it 'should initialize with default values' do
+      result = AccurateRipResult.new
+      expect(result.status).to eq(false)
+      expect(result.computed_v1).to eq({})
+      expect(result.computed_v2).to eq({})
+      expect(result.pressings).to eq([])
+      expect(result.track_results).to eq({})
+    end
+  end
+
+  describe '#setComputedChecksums' do
+    it 'should set computed checksums for a track' do
+      result = AccurateRipResult.new
+      result.setComputedChecksums(1, 0x12345678, 0x87654321)
+      expect(result.computed_v1[1]).to eq(0x12345678)
+      expect(result.computed_v2[1]).to eq(0x87654321)
+    end
+  end
+
+  describe '#addPressing' do
+    it 'should add pressing data' do
+      result = AccurateRipResult.new
+      pressing = { tracks: { 1 => { confidence: 5, crc: 0xABCDEF00 } } }
+      result.addPressing(pressing)
+      expect(result.pressings.size).to eq(1)
+      expect(result.pressings[0][:tracks][1][:crc]).to eq(0xABCDEF00)
+    end
+  end
+
+  describe '#setTrackResult' do
+    it 'should set verification result for a track' do
+      result = AccurateRipResult.new
+      result.setTrackResult(1, true, :v2, 0, 10)
+      expect(result.track_results[1][:matched]).to eq(true)
+      expect(result.track_results[1][:version]).to eq(:v2)
+      expect(result.track_results[1][:confidence]).to eq(10)
+    end
+  end
+
+  describe '#finalize' do
+    it 'should set status to true if all tracks matched' do
+      result = AccurateRipResult.new
+      result.setTrackResult(1, true, :v2, 0, 10)
+      result.setTrackResult(2, true, :v1, 0, 5)
+      result.finalize
+      expect(result.status).to eq(true)
+    end
+
+    it 'should set status to false if any track mismatched' do
+      result = AccurateRipResult.new
+      result.setTrackResult(1, true, :v2, 0, 10)
+      result.setTrackResult(2, false, nil, nil, nil)
+      result.finalize
+      expect(result.status).to eq(false)
+    end
+  end
+
+  describe '#toStr' do
+    it 'should return an appropriate message when no pressing data exists' do
+      result = AccurateRipResult.new
+      output = result.toStr
+      expect(output).to include('No entry found in the database')
+    end
+
+    it 'should return a string containing match results' do
+      result = AccurateRipResult.new
+      result.addPressing({ tracks: { 1 => { confidence: 5, crc: 0x12345678 } } })
+      result.setComputedChecksums(1, 0x12345678, 0x87654321)
+      result.setTrackResult(1, true, :v1, 0, 5)
+      result.finalize
+      output = result.toStr
+      expect(output).to include('Matched')
+      expect(output).to include('12345678(5)')
+    end
+  end
+end
+
+describe AccurateRip do
+  let(:disc) { double('Disc').as_null_object }
+  let(:prefs) { double('Preferences').as_null_object }
+
+  before(:each) do
+    allow(prefs).to receive(:debug).and_return(false)
+    allow(disc).to receive(:audiotracks).and_return(10)
+    allow(disc).to receive(:freedbDiscid).and_return('7F087C0A')
+
+    # Mock track start positions
+    start_sectors = { 1 => 0, 2 => 13209, 3 => 36539, 4 => 53497, 5 => 68172,
+                      6 => 81097, 7 => 87182, 8 => 106732, 9 => 122218, 10 => 124080 }
+    start_sectors.each do |track, sector|
+      allow(disc).to receive(:getStartSector).with(track).and_return(sector)
+    end
+    allow(disc).to receive(:getLengthSector).with(10).and_return(38839)
+  end
+
+  describe '#initialize' do
+    it 'should initialize with disc and prefs' do
+      ar = AccurateRip.new(disc, prefs)
+      expect(ar).to be_a(AccurateRip)
+    end
+  end
+
+  describe 'CRC calculation' do
+    let(:ar) { AccurateRip.new(disc, prefs) }
+
+    it 'should calculate V1 CRC' do
+      # Simple test data: 8 bytes (2 DWORD)
+      audio_data = [0x12345678, 0x9ABCDEF0].pack('V*')
+      # Set track count to 3 (use middle track to avoid skipping sectors 1/last)
+      allow(disc).to receive(:audiotracks).and_return(3)
+      v1_crc = ar.send(:computeV1Checksum, 2, audio_data)
+      expect(v1_crc).to be_a(Integer)
+    end
+
+    it 'should calculate V2 CRC' do
+      audio_data = [0x12345678, 0x9ABCDEF0].pack('V*')
+      allow(disc).to receive(:audiotracks).and_return(3)
+      v2_crc = ar.send(:computeV2Checksum, 2, audio_data)
+      expect(v2_crc).to be_a(Integer)
+    end
+  end
+
+  describe 'Disc Identifier construction' do
+    it 'should construct Disc Identifier correctly' do
+      ar = AccurateRip.new(disc, prefs)
+      ar.send(:buildDiscIdent)
+      disc_ident = ar.instance_variable_get(:@disc_ident)
+
+      expect(disc_ident[:track_count]).to eq(10)
+      # TrackOffsetsAdded should be calculated
+      expect(disc_ident[:track_offsets_added]).to be > 0
+      # TrackOffsetsMultiplied should be calculated
+      expect(disc_ident[:track_offsets_multiplied]).to be > 0
+      # FreeDBID should be set
+      expect(disc_ident[:freedb_id]).to eq(0x7F087C0A)
+    end
+  end
+
+  describe 'bin file parsing' do
+    it 'should parse bin data correctly' do
+      ar = AccurateRip.new(disc, prefs)
+      result = AccurateRipResult.new
+
+      # Create sample bin data: DiscIdent (13 bytes) + Track (9 bytes x 2)
+      bin_data = ""
+      # DiscIdent: track_count=2, offsets_added, offsets_multiplied, freedb_id (4 bytes each LE)
+      bin_data += [2].pack('C')  # track_count (1 byte)
+      bin_data += [1000].pack('V')  # track_offsets_added (4 bytes)
+      bin_data += [2000].pack('V')  # track_offsets_multiplied (4 bytes)
+      bin_data += [0x12345678].pack('V')  # freedb_id (4 bytes)
+      # Track 1: confidence=5, crc=0x12345678, offset_find_crc=0
+      bin_data += [5].pack('C')
+      bin_data += [0x12345678].pack('V')
+      bin_data += [0].pack('V')
+      # Track 2: confidence=3, crc=0xABCDEF00, offset_find_crc=0
+      bin_data += [3].pack('C')
+      bin_data += [0xABCDEF00].pack('V')
+      bin_data += [0].pack('V')
+
+      temp_file = Tempfile.new(['test_accuraterip', '.bin'])
+      temp_file.binmode
+      temp_file.write(bin_data)
+      temp_file.close
+
+      ar.send(:parseAccurateRipData, temp_file.path, result)
+      temp_file.unlink
+
+      expect(result.pressings.size).to eq(1)
+      expect(result.pressings[0][:tracks][1][:confidence]).to eq(5)
+      expect(result.pressings[0][:tracks][1][:crc]).to eq(0x12345678)
+      expect(result.pressings[0][:tracks][2][:confidence]).to eq(3)
+      expect(result.pressings[0][:tracks][2][:crc]).to eq(0xABCDEF00)
+    end
+  end
+end


### PR DESCRIPTION
Implemented AccurateRip CRC calculation and comparison with track records from the AccurateRip server, based on the algorithm detailed here:
https://forum.dbpoweramp.com/forum/other-topics/developers-corner/20117-accuraterip-crc-calculation?20641=

The comparison process is configurable. It not only verifies the data after ripping but can also terminate an iterative ripping process as soon as a match is confirmed.


## New Preferences
| Preference | Type | Default | Description |
|---------|------|---------|-------------|
| `accRip` | boolean | false | Enable/disable AccurateRip verification |
| `accRipEveryTime` | boolean | false | When enabled, perform AccurateRip verification after each rip trial and finish early if verification succeeds |

## Behavior
### `accRip = false`
- AccurateRip verification is completely disabled

### `accRip = true`, `accRipEveryTime = false`
- AccurateRip verification runs once after all ripping is complete

### `accRip = true`, `accRipEveryTime = true`
- AccurateRip verification runs after each rip trial
- If all tracks are verified successfully, the ripping process finishes immediately without additional trials

## UI Changes


**CLI (Secure Ripping Preferences menu):**
```
8) AccurateRip verification [*]
9) AccurateRip every trial (Finish early if verified successfully) [*]
```

**GTK GUI (Secure Ripping tab → Ripping options):**
- Added two checkboxes for AccurateRip settings
- "AccurateRip every trial" checkbox is disabled when "AccurateRip verification" is unchecked
