### PR TITLE
Add CTDB (CUETools Database) Verify and Submit features

### DIFF
--- a/lib/rubyripper/cli/cliPreferences.rb
+++ b/lib/rubyripper/cli/cliPreferences.rb
@@ -146,9 +146,10 @@ private
     @out.puts ' 7) ' + _("Maximum trials") + ": %s" % [@prefs.maxTries == 0 ? "no\
  maximum" : @prefs.maxTries]
     @out.puts ' 8) ' + _("AccurateRip verification %s") % [showBool(@prefs.accRip)]
-    @out.puts ' 9) ' + _("AccurateRip every trial (Finish early if verified successfully) %s") % [showBool(@prefs.accRipEveryTime)]
-    @out.puts '10) ' + _("Eject disc after ripping %s") % [showBool(@prefs.eject)]
-    @out.puts '11) ' + _("Only keep log when errors %s") % [showBool(@prefs.noLog)]
+    @out.puts ' 9) ' + _("CTDB verification (image rip only) %s") % [showBool(@prefs.ctdb)]
+    @out.puts '10) ' + _("Verify every trial (Finish early if verified successfully) %s") % [showBool(@prefs.verifyEverytime)]
+    @out.puts '11) ' + _("Eject disc after ripping %s") % [showBool(@prefs.eject)]
+    @out.puts '12) ' + _("Only keep log when errors %s") % [showBool(@prefs.noLog)]
     @out.puts '99) ' + _("Back to settings main menu")
     @out.puts ""
     @int.get("Please type the number of the setting you wish to change", 99)
@@ -168,9 +169,10 @@ private
       when 6 then @prefs.reqMatchesErrors = @int.get(_("Match erronous chunks"), 3)
       when 7 then @prefs.maxTries = @int.get(_("Maximum trials"), 5)
       when 8 then switchBool('accRip')
-      when 9 then switchBool('accRipEveryTime')
-      when 10 then switchBool('eject')
-      when 11 then switchBool('noLog')
+      when 9 then switchBool('ctdb')
+      when 10 then switchBool('verifyEverytime')
+      when 11 then switchBool('eject')
+      when 12 then switchBool('noLog')
     else noValidChoiceMessage(choice)
     end
     loopSubMenuRipping() unless choice == 99

--- a/lib/rubyripper/ctdb.rb
+++ b/lib/rubyripper/ctdb.rb
@@ -1,0 +1,174 @@
+#!/usr/bin/env ruby
+#    Rubyripper - A secure ripper for Linux/BSD/OSX
+#    Copyright (C) 2007 - 2010  Bouke Woudstra (boukewoudstra@gmail.com)
+#
+#    This file is part of Rubyripper. Rubyripper is free software: you can
+#    redistribute it and/or modify it under the terms of the GNU General
+#    Public License as published by the Free Software Foundation, either
+#    version 3 of the License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+require 'rexml/document'
+require 'tempfile'
+require 'rubyripper/preferences/main'
+require 'rubyripper/system/execute'
+require 'rubyripper/disc/cuesheet'
+require 'shellwords'
+
+# Class to hold the verification results of CTDB
+class CtdbResult
+  attr_reader :status,         # status string from ctdb-cli (e.g., 'found', 'not_found', 'failure')
+              :confidence,     # confidence value from database
+              :message,        # additional message from ctdb-cli
+              :entries         # array of database entries
+
+  def initialize
+    @status = nil
+    @confidence = 0
+    @message = nil
+    @entries = []
+  end
+
+  # Parse XML output from ctdb-cli verify command
+  def parseXml(xml_string)
+    return if xml_string.nil? || xml_string.empty?
+
+    begin
+      doc = REXML::Document.new(xml_string)
+      verify_element = doc.elements['ctdb/verify_result']
+      return unless verify_element
+
+      @status = verify_element.attributes['status']
+      @message = verify_element.attributes['message']
+      @confidence = verify_element.attributes['confidence'].to_i
+
+      # Parse entries
+      verify_element.elements.each('entry') do |entry|
+        entry_data = {
+          conf: entry.attributes['conf'].to_i,
+          crc: entry.attributes['crc'],
+          status: entry.attributes['status']
+        }
+        @entries << entry_data
+      end
+    rescue REXML::ParseException => e
+      @message = "XML parse error: #{e.message}"
+      @status = 'failure'
+    end
+  end
+
+  # Check if database entry was found (regardless of match result)
+  def entryFound?
+    !@entries.empty? || @status == 'found'
+  end
+
+  # Generate string for logging
+  def toStr
+    lines = []
+    lines << "CTDB verification results:"
+
+    if @status == 'not_found' || @entries.empty?
+      lines << "  No entry found in the database"
+      return lines.join("\n")
+    end
+
+    lines << "  Status: #{@status}"
+    lines << "  Confidence: #{@confidence}" if @confidence > 0
+    lines << "  Message: #{@message}" if @message && !@message.empty?
+
+    unless @entries.empty?
+      lines << ""
+      lines << "  Database entries:"
+      @entries.each_with_index do |entry, idx|
+        lines << "    #{idx + 1}. Confidence: #{entry[:conf]}, CRC: #{entry[:crc]}, Status: #{entry[:status]}"
+      end
+    end
+
+    lines << ""
+    lines << "  #{@status == 'found' ? 'Verification successful' : 'Verification failed'}"
+
+    lines.join("\n")
+  end
+end
+
+# Class to perform CD verification using CTDB (CUETools Database)
+# This class follows the same pattern as AccurateRip class
+class Ctdb
+  def initialize(disc, cdrdao, fileScheme, prefs = nil, deps = nil, exec = nil)
+    @disc = disc
+    @cdrdao = cdrdao
+    @fileScheme = fileScheme
+    @prefs = prefs || Preferences::Main.instance
+    @deps = deps || Dependency.instance
+    @exec = exec || Execute.new
+  end
+
+  # Verify image file and return CtdbResult
+  # file_path: path to the WAV image file
+  def verifyImage(file_path)
+    result = CtdbResult.new
+
+    # Check if ctdb-cli is installed
+    unless @deps.installed?('ctdb-cli')
+      result.instance_variable_set(:@message, "ctdb-cli not installed")
+      return result
+    end
+
+    return result unless File.exist?(file_path)
+
+    # Generate temporary CUE sheet pointing to the image file
+    temp_cue = generateTempCue(file_path)
+    return result unless temp_cue
+
+    begin
+      # Execute ctdb-cli verify command
+      xml_output = executeVerify(temp_cue.path)
+      result.parseXml(xml_output)
+    ensure
+      # Clean up temporary CUE file
+      temp_cue.close
+      temp_cue.unlink
+    end
+
+    result
+  end
+
+  private
+
+  # Generate a temporary CUE sheet pointing to the specified WAV file
+  def generateTempCue(wav_path)
+    # Create a cuesheet that references the temporary WAV file
+    cuesheet = Cuesheet.new(@disc, @cdrdao, @fileScheme, nil, @prefs, @deps)
+    cue_content = cuesheet.save('wav', wav_path)
+
+    # Create the temp CUE in the same directory as the wav_path provided.
+    dir = File.dirname(wav_path)
+    temp_cue = Tempfile.new(['ctdb_verify', '.cue'], dir)
+    temp_cue.write(cue_content.join("\n"))
+    temp_cue.flush
+
+    temp_cue
+  rescue StandardError => e
+    puts "CTDB: Error generating temp CUE: #{e.message}" if @prefs.debug
+    nil
+  end
+
+  # Execute ctdb-cli verify command and return XML output
+  def executeVerify(cue_path)
+    command = "ctdb-cli --xml verify #{Shellwords.escape(cue_path)}"
+    stdout_str, stderr_str, status = Open3.capture3(command)
+    puts "CTDB stderr: #{stderr_str}" if @prefs.debug && !stderr_str.empty?
+    stdout_str
+
+  rescue StandardError => e
+    puts "CTDB: Error executing ctdb-cli: #{e.message}" if @prefs.debug
+    nil
+  end
+end

--- a/lib/rubyripper/ctdb.rb
+++ b/lib/rubyripper/ctdb.rb
@@ -85,7 +85,7 @@ class CtdbResult
       return lines.join("\n")
     end
 
-    lines << "  #{@status ? 'Verification successful' : 'Verification failed'}"
+    lines << "  Status: #{@status ? 'Verification successful' : 'Verification failed'}"
     lines << "  Confidence: #{@confidence}/#{@total_entries}"
     lines << "  Message: #{@message}" if @message && !@message.empty?
 

--- a/lib/rubyripper/ctdb.rb
+++ b/lib/rubyripper/ctdb.rb
@@ -199,9 +199,9 @@ class Ctdb
 
         res_status = submit_element.attributes['status']
         if @prefs.debug
-          res_status == 'submitted' || res_status == 'dry_run'
+          res_status == 'dry_run'
         else
-          res_status == 'submitted'
+          res_status == 'submitted' && submit_element.elements['response'].attributes['status'] == 'success'
         end
       rescue REXML::ParseException => e
         puts "CTDB: XML parse error during submit: #{e.message}" if @prefs.debug

--- a/lib/rubyripper/disc/cuesheet.rb
+++ b/lib/rubyripper/disc/cuesheet.rb
@@ -48,10 +48,13 @@ class Cuesheet
   end
 
   # return an array with the cuesheet for a codec
-  def save(codec)
+  # single_file_path: optional path to use instead of FileScheme (for temp CUE generation)
+  def save(codec, single_file_path = nil)
     @cuesheet = Array.new
+    @single_file_path = single_file_path
     printDiscData
     @prefs.image ? printTrackDataImage(codec) : printTrackData(codec)
+    @single_file_path = nil
     @cuesheet
   end
 
@@ -96,7 +99,9 @@ private
 
    #writes the location of the file in the Cue
   def printFileLine(codec, track=nil)
-    @cuesheet << "FILE \"#{File.basename(@fileScheme.getFile(codec, track))}\" #{getCueFileType(codec)}"
+    # Use single_file_path if set (for temp CUE generation), otherwise use FileScheme
+    file_path = @single_file_path || @fileScheme.getFile(codec, track)
+    @cuesheet << "FILE \"#{File.basename(file_path)}\" #{getCueFileType(codec)}"
   end
   
   def printTrackLine(track)

--- a/lib/rubyripper/disc/disc.rb
+++ b/lib/rubyripper/disc/disc.rb
@@ -23,7 +23,7 @@ require 'rubyripper/preferences/main'
 
 # A helper class to hide lower level details
 class Disc
-attr_reader :metadata
+attr_reader :metadata, :cdrdao
 
   def initialize(cdpar=nil, freedb=nil, musicbrainz=nil, deps=nil, prefs=nil)
     @cdparanoia = cdpar ? cdpar : ScanDiscCdparanoia.new()

--- a/lib/rubyripper/disc/scanDiscCdinfo.rb
+++ b/lib/rubyripper/disc/scanDiscCdinfo.rb
@@ -28,7 +28,8 @@ class ScanDiscCdinfo
   include AudioCalculations
 
   attr_reader :status, :version, :discMode, :deviceName, :totalSectors,
-      :playtime, :audiotracks, :firstAudioTrack, :dataTracks
+      :playtime, :audiotracks, :firstAudioTrack, :dataTracks,
+      :vendor, :model
   
   # Cd-info starts all tracks with 2 seconds extra if compared with cdparanoia
   OFFSET_CDINFO = -150

--- a/lib/rubyripper/log.rb
+++ b/lib/rubyripper/log.rb
@@ -202,6 +202,15 @@ class Log
     add("\n")
   end
 
+  # Output CTDB verification results to log
+  def ctdbResult(result)
+    add("\n")
+    add("=" * 60 + "\n")
+    add(result.toStr + "\n")
+    add("=" * 60 + "\n")
+    add("\n")
+  end
+
 
   def summary() #Give an overview of errors
     if @encodingErrors ; @short_summary += _("\nWARNING: ENCODING ERRORS WERE DETECTED\n") ; end

--- a/lib/rubyripper/preferences/data.rb
+++ b/lib/rubyripper/preferences/data.rb
@@ -66,9 +66,13 @@ module Preferences
     # Enable AccurateRip verification
     attr_accessor :accRip
 
-    # If true, perform AccurateRip verification after each trial
+    # CTDB PREFERENCES
+    # Enable CTDB verification (image rip only)
+    attr_accessor :ctdb
+
+    # If true, perform verification after each trial
     # and finish early when all tracks match.
-    attr_accessor :accRipEveryTime
+    attr_accessor :verifyEverytime
 
     # TOC ANALYSIS PREFERENCES
     # Create a cuesheet

--- a/lib/rubyripper/preferences/setDefaults.rb
+++ b/lib/rubyripper/preferences/setDefaults.rb
@@ -46,7 +46,8 @@ module Preferences
       @data.eject = true
       @data.noLog = false
       @data.accRip = false
-      @data.accRipEveryTime = false
+      @data.ctdb = false
+      @data.verifyEverytime = false
     end
 
     def setTocAnalysisDefaults

--- a/lib/rubyripper/secureRip.rb
+++ b/lib/rubyripper/secureRip.rb
@@ -590,7 +590,7 @@ is #{@disc.getFileSize(track)} bytes." if @prefs.debug
     ctdb_found = ctdb_result && ctdb_result.respond_to?(:entryFound?) && ctdb_result.entryFound?
 
     ar_success = ar_result && ar_result.status
-    ctdb_success = ctdb_result && ctdb_result.status == 'found'
+    ctdb_success = ctdb_result && ctdb_result.status
 
     if ar_found && ctdb_found
       # Both have data: both must succeed

--- a/lib/rubyripper/system/dependency.rb
+++ b/lib/rubyripper/system/dependency.rb
@@ -123,7 +123,8 @@ calculation unless %s is installed.") % ['Discid'],
       'normalize' => _("You won't be able to normalize audio files."),
       'cdrdao' => _("You won't be able to make cuesheets"),
       'cd-info' => _("Cd-info helps to detect data tracks."),
-      'ls' => _("Show rights in case of problems")
+      'ls' => _("Show rights in case of problems"),
+      'ctdb-cli' => _("You won't be able to perform CTDB verification.")
     }
   end
 
@@ -165,6 +166,7 @@ calculation unless %s is installed.") % ['Discid'],
     @optionalDeps << ['cd-info', installed?('cd-info')]
     @optionalDeps << ['ls', installed?('ls')]
     @optionalDeps << ['diskutil', installed?('diskutil')]
+    @optionalDeps << ['ctdb-cli', installed?('ctdb-cli')]
   end
 
   # check for ruby-gtk3

--- a/spec/ctdb_spec.rb
+++ b/spec/ctdb_spec.rb
@@ -1,0 +1,197 @@
+#!/usr/bin/env ruby
+#    Rubyripper - A secure ripper for Linux/BSD/OSX
+#    Copyright (C) 2007 - 2010 Bouke Woudstra (boukewoudstra@gmail.com)
+#
+#    This file is part of Rubyripper. Rubyripper is free software: you can
+#    redistribute it and/or modify it under the terms of the GNU General
+#    Public License as published by the Free Software Foundation, either
+#    version 3 of the License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>
+
+require 'rubyripper/ctdb'
+
+describe CtdbResult do
+  let(:result) { CtdbResult.new }
+
+  describe '#initialize' do
+    it 'should initialize status as false' do
+      expect(result.status).to be false
+    end
+
+    it 'should initialize confidence as 0' do
+      expect(result.confidence).to eq(0)
+    end
+
+    it 'should initialize total_entries as 0' do
+      expect(result.total_entries).to eq(0)
+    end
+
+    it 'should initialize entries as an empty array' do
+      expect(result.entries).to eq([])
+    end
+  end
+
+  describe '#parseXml' do
+    context 'status determination tests' do
+      it 'should set status to true if confidence is 2 or more' do
+        xml = <<~XML
+          <ctdb xmlns="http://db.cuetools.net/ns/mmd-1.0#">
+            <verify_result confidence="2" total_entries="10"/>
+          </ctdb>
+        XML
+        result.parseXml(xml)
+        expect(result.status).to be true
+      end
+
+      it 'should set status to true if confidence is 1 and total_entries is 1' do
+        xml = <<~XML
+          <ctdb xmlns="http://db.cuetools.net/ns/mmd-1.0#">
+            <verify_result confidence="1" total_entries="1"/>
+          </ctdb>
+        XML
+        result.parseXml(xml)
+        expect(result.status).to be true
+      end
+
+      it 'should set status to false if confidence is 1 and total_entries is 2 or more' do
+        xml = <<~XML
+          <ctdb xmlns="http://db.cuetools.net/ns/mmd-1.0#">
+            <verify_result confidence="1" total_entries="2"/>
+          </ctdb>
+        XML
+        result.parseXml(xml)
+        expect(result.status).to be false
+      end
+
+      it 'should set status to false if confidence is 0' do
+        xml = <<~XML
+          <ctdb xmlns="http://db.cuetools.net/ns/mmd-1.0#">
+            <verify_result confidence="0" total_entries="10"/>
+          </ctdb>
+        XML
+        result.parseXml(xml)
+        expect(result.status).to be false
+      end
+    end
+
+    context 'successful parsing' do
+      let(:xml) do
+        <<~XML
+          <?xml version="1.0" encoding="UTF-8"?>
+          <ctdb xmlns="http://db.cuetools.net/ns/mmd-1.0#">
+            <verify_result toc="12345" status="found" confidence="10" total_entries="2">
+              <entry id="1" conf="8" crc="ABCD1234" offset="0" status="verified" has_errors="false" can_recover="false">
+                <track number="1" local_crc="1111" remote_crc="1111" matched="true"/>
+              </entry>
+              <entry id="2" conf="5" crc="EFGH5678" offset="0" status="verified" has_errors="false" can_recover="false"/>
+            </verify_result>
+          </ctdb>
+        XML
+      end
+
+      before { result.parseXml(xml) }
+
+      it 'should set status to true' do
+        expect(result.status).to be true
+      end
+
+      it 'should set confidence to 10' do
+        expect(result.confidence).to eq(10)
+      end
+
+      it 'should set total_entries to 2' do
+        expect(result.total_entries).to eq(2)
+      end
+
+      it 'should have 2 entries' do
+        expect(result.entries.size).to eq(2)
+      end
+
+      it 'should return true for #entryFound?' do
+        expect(result.entryFound?).to be true
+      end
+    end
+
+    context 'when status is failure' do
+      let(:xml) do
+        <<~XML
+          <?xml version="1.0" encoding="UTF-8"?>
+          <ctdb xmlns="http://db.cuetools.net/ns/mmd-1.0#">
+            <verify_result status="failure" message="Audio file not found."/>
+          </ctdb>
+        XML
+      end
+
+      before { result.parseXml(xml) }
+
+      it 'should set status to false' do
+        expect(result.status).to be false
+      end
+
+      it 'should set message to the error message' do
+        expect(result.message).to eq('Audio file not found.')
+      end
+    end
+
+    context 'when XML parsing fails' do
+      let(:invalid_xml) { '<invalid><xml>' }
+
+      before { result.parseXml(invalid_xml) }
+
+      it 'should set status to false' do
+        expect(result.status).to be false
+      end
+
+      it 'should include error information in message' do
+        expect(result.message).to include('XML parse error')
+      end
+    end
+  end
+
+  describe '#toStr' do
+    context 'when successful' do
+      let(:xml) do
+        <<~XML
+          <ctdb xmlns="http://db.cuetools.net/ns/mmd-1.0#">
+            <verify_result confidence="2" total_entries="1">
+              <entry id="1" conf="2" crc="ABCD" status="verified"/>
+            </verify_result>
+          </ctdb>
+        XML
+      end
+
+      before { result.parseXml(xml) }
+
+      it 'should include "Verification successful"' do
+        expect(result.toStr).to include('Verification successful')
+      end
+
+      it 'should include "Confidence: 2"' do
+        expect(result.toStr).to include('Confidence: 2')
+      end
+    end
+
+    context 'when not found' do
+      let(:xml) do
+        <<~XML
+          <ctdb xmlns="http://db.cuetools.net/ns/mmd-1.0#">
+            <verify_result confidence="0" total_entries="0"/>
+          </ctdb>
+        XML
+      end
+
+      before { result.parseXml(xml) }
+
+      it 'should include "No entry found"' do
+        expect(result.toStr).to include('No entry found in the database')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR enables verification of CD rip results against the [CUETools Database (CTDB)](https://db.cue.tools/) and allows for result submission. This adds an extra layer of data integrity validation alongside the existing AccurateRip support.

# Key Features
- Verify<br> Verifies the integrity of the ripped disc image.
- Submit<br> Automatically submits rip results (checksums, etc.) to CTDB after a successful rip.

# Behavior Details
- After rip completion, a temporary CUE sheet is generated, and ctdb-cli verify is executed.
- `ctdb-cli submit` is triggered after ripping is completely finished.
  - In Debug mode (debug: true), the submission runs as a dry_run and does not actually upload data to the server.
- A new CTDB preference flag has been added. It can be toggled independently of AccurateRip.
- Verification is executed every rip trial if `verifyEverytime` is `true`. If AccurateRip, CTDB, and verifyEveryTime are all enabled, early termination will occur when verification is successful for both accurateRip and CTDB.

# Constraints
- Dependency: The [ctdb-cli](https://github.com/Masterisk-F/ctdb-cli) must be installed and available in the system path.
- **CTDB feature applies only to "Image Rip" mode** because CTDB verification relies on the full disc structure (CUE sheet). The feature is skipped when performing individual Track Rips.
