### PR TITLE
Add MusicBrainz disc ID submission URL display

### DIFF
--- a/lib/rubyripper/cli/cliDisc.rb
+++ b/lib/rubyripper/cli/cliDisc.rb
@@ -79,6 +79,7 @@ private
   def showFreedb()
     showDiscInfo()
     showTrackInfo()
+    showMusicbrainzIDSubmitInfo()
   end
 
   def showDiscInfo
@@ -103,6 +104,13 @@ private
     @out.puts "TRACK INFO"
     trackInfo().each{|key, value| @out.puts "#{key}. #{value}"}
     @out.puts ""
+  end
+
+  def showMusicbrainzIDSubmitInfo
+    if discReady?
+      @out.puts _("Submit DiscID to MusicBrainz via : %s") % [@cd.musicbrainzSubmitURL]
+      @out.puts ""
+    end
   end
 
   # build the trackinfo

--- a/lib/rubyripper/disc/calcMusicbrainzID.rb
+++ b/lib/rubyripper/disc/calcMusicbrainzID.rb
@@ -42,6 +42,18 @@ class CalcMusicbrainzID
     @discid
   end
 
+  # fetch the MusicBrainz submit URL
+  def musicbrainzSubmitURL
+    getMusicBrainzLookupPath() if @musicbrainzLookupPath.nil?
+    url = String.new
+    url << 'https://musicbrainz.org/cdtoc/attach?toc='
+    url << "#{@firstTrack}+#{@lastTrack}"
+    (0..@lastTrack).each do |tracknumber|
+      url << "+#{@offsets[tracknumber]}"
+    end
+    url
+  end
+
 private
 
   # try to calculate it ourselves, prefer cd-info if available

--- a/lib/rubyripper/disc/disc.rb
+++ b/lib/rubyripper/disc/disc.rb
@@ -65,6 +65,7 @@ attr_reader :metadata, :cdrdao
   # helper functions for @musicbrainz
   def musicbrainzLookupPath ; @calcMusicbrainzID.musicbrainzLookupPath ; end
   def musicbrainzDiscid ; @calcMusicbrainzID.discid ; end
+  def musicbrainzSubmitURL ; @calcMusicbrainzID.musicbrainzSubmitURL ; end
 
   # this can take a while so run in background
   def startExtendedTocScan()

--- a/spec/disc/disc_spec.rb
+++ b/spec/disc/disc_spec.rb
@@ -92,6 +92,11 @@ describe Disc do
       expect(musicbrainz).to receive(:discid).once.and_return true
       disc.musicbrainzDiscid()
     end
+
+    it "should forward the musicbrainzSubmitURL method to the calcMusicbrainzID object" do
+      expect(musicbrainz).to receive(:musicbrainzSubmitURL).once.and_return 'https://musicbrainz.org/cdtoc/attach?toc=...'
+      expect(disc.musicbrainzSubmitURL()).to eq('https://musicbrainz.org/cdtoc/attach?toc=...')
+    end
     
     # all unknown commands should be redirected to cdparanoia
     it "should pass any other command to cdparanoia" do

--- a/spec/disc/musicbrainzLookupPath_spec.rb
+++ b/spec/disc/musicbrainzLookupPath_spec.rb
@@ -48,4 +48,26 @@ describe CalcMusicbrainzID do
       expect(@musicbrainz.discid).to eq("I5l9cCSFccLKFEKS.7wqSZAorPU-")
     end
   end
+
+  context "Try to calculate MusicBrainz submit URL" do
+    before(:each) do
+      @start = {1=>0, 2=>22617, 3=>41737, 4=>58167, 5=>71952, 6=>91225,
+7=>104502, 8=>115230, 9=>132015, 10=>143782, 11=>159720, 12=>174447, 13=>267107+11400}
+      expect(disc).to receive(:advancedTocScanner).once.and_return scanner
+    end
+
+    it "should generate a valid MusicBrainz submit URL from disc TOC data" do
+      expect(scanner).to receive(:respond_to?).with(:dataTracks).at_least(:once).and_return true
+
+      expect(scanner).to receive(:dataTracks).at_least(3).and_return([13])
+      expect(scanner).to receive(:firstAudioTrack).at_least(:once).and_return(1)
+      expect(scanner).to receive(:audiotracks).at_least(:once).and_return(12)
+      (1..13).each do |number|
+        expect(scanner).to receive(:getStartSector).with(number).at_least(:once).and_return @start[number]
+      end
+
+      expected_url = "https://musicbrainz.org/cdtoc/attach?toc=1+12+267257+150+22767+41887+58317+72102+91375+104652+115380+132165+143932+159870+174597"
+      expect(@musicbrainz.musicbrainzSubmitURL).to eq(expected_url)
+    end
+  end
 end


### PR DESCRIPTION
Display the MusicBrainz disc ID submission URL after track info in the CLI. This allows users to easily submit disc IDs for CDs not yet in the database.