### PR TITLE
Show MusicBrainz submit URL only on metadata fetch failure

### DIFF
--- a/lib/rubyripper/cli/cliDisc.rb
+++ b/lib/rubyripper/cli/cliDisc.rb
@@ -107,7 +107,7 @@ private
   end
 
   def showMusicbrainzIDSubmitInfo
-    if discReady?
+    if discReady? && @cd.musicbrainz_failed
       @out.puts _("Submit DiscID to MusicBrainz via : %s") % [@cd.musicbrainzSubmitURL]
       @out.puts ""
     end

--- a/lib/rubyripper/disc/disc.rb
+++ b/lib/rubyripper/disc/disc.rb
@@ -23,7 +23,7 @@ require 'rubyripper/preferences/main'
 
 # A helper class to hide lower level details
 class Disc
-attr_reader :metadata, :cdrdao
+attr_reader :metadata, :cdrdao, :musicbrainz_failed
 
   def initialize(cdpar=nil, freedb=nil, musicbrainz=nil, deps=nil, prefs=nil)
     @cdparanoia = cdpar ? cdpar : ScanDiscCdparanoia.new()
@@ -105,8 +105,9 @@ attr_reader :metadata, :cdrdao
   # helper function to load metadata object
   def setMetadata(metadata=nil)
     require 'rubyripper/metadata/main'
-    @metadata = metadata ? metadata : Metadata::Main.new(self)
-    @metadata = @metadata.get()
+    main = metadata ? metadata : Metadata::Main.new(self)
+    @metadata = main.get()
+    @musicbrainz_failed = main.musicbrainz_failed
   end
 end
 

--- a/lib/rubyripper/metadata/main.rb
+++ b/lib/rubyripper/metadata/main.rb
@@ -28,18 +28,24 @@ module Metadata
       @no_provider = no_provider
     end
     
+    attr_reader :musicbrainz_failed
+
     # decide which metadataprovider is active
     # fall back to other metadata provider if no matches
     def get
+      @musicbrainz_failed = false
       setProvidersPriority()
       @providers.each do |provider|
         startup(provider)
-        break if provider == 'none' || @provider.status == 'ok' || @provider.status == 'multipleRecords'
+        status = @provider.status
+        stopped = provider == 'none' || status == 'ok' || status == 'multipleRecords'
+        @musicbrainz_failed = true if provider == 'musicbrainz' && !stopped
+        break if stopped
       end
-      
+
       return @provider
     end
-    
+
     private
     
     def setProvidersPriority

--- a/spec/disc/disc_spec.rb
+++ b/spec/disc/disc_spec.rb
@@ -104,4 +104,22 @@ describe Disc do
       disc.any_other_command()
     end
   end
+
+  context "When metadata fetching fails for MusicBrainz" do
+    let(:main_double) {double('Metadata::Main')}
+
+    it "should capture musicbrainz_failed from the metadata main class" do
+      expect(main_double).to receive(:get).once.and_return true
+      expect(main_double).to receive(:musicbrainz_failed).once.and_return true
+      disc.send(:setMetadata, main_double)
+      expect(disc.musicbrainz_failed).to eq(true)
+    end
+
+    it "should capture musicbrainz_failed as false when metadata succeeds" do
+      expect(main_double).to receive(:get).once.and_return true
+      expect(main_double).to receive(:musicbrainz_failed).once.and_return false
+      disc.send(:setMetadata, main_double)
+      expect(disc.musicbrainz_failed).to eq(false)
+    end
+  end
 end

--- a/spec/metadata/main_spec.rb
+++ b/spec/metadata/main_spec.rb
@@ -72,7 +72,7 @@ describe Metadata::Main do
       before(:each) do
         allow(prefs).to receive(:metadataProvider).and_return("gnudb")
       end
-      
+
       it "should first fall back to Musicbrainz if Gnudb fails" do
         expect(freedb).to receive(:get)
         expect(freedb).to receive(:status).and_return 'mayday'
@@ -80,7 +80,7 @@ describe Metadata::Main do
         expect(musicbrainz).to receive(:status).and_return 'ok'
         expect(main.get).to eq(musicbrainz)
       end
-      
+
       it "should fall back to none if Musicbrainz fails as well" do
         expect(freedb).to receive(:get)
         expect(freedb).to receive(:status).and_return 'mayday'
@@ -88,6 +88,58 @@ describe Metadata::Main do
         expect(musicbrainz).to receive(:status).and_return 'mayday'
         expect(main.get).to eq(no_provider)
       end
+    end
+  end
+
+  context "When checking if MusicBrainz metadata fetching failed" do
+    it "should be false if musicbrainz is the preference and it succeeds" do
+      allow(prefs).to receive(:metadataProvider).and_return("musicbrainz")
+      expect(musicbrainz).to receive(:get)
+      expect(musicbrainz).to receive(:status).and_return 'ok'
+      main.get
+      expect(main.musicbrainz_failed).to eq(false)
+    end
+
+    it "should be true if musicbrainz is the preference and it returns noMatches" do
+      allow(prefs).to receive(:metadataProvider).and_return("musicbrainz")
+      expect(musicbrainz).to receive(:get)
+      expect(musicbrainz).to receive(:status).and_return 'noMatches'
+      allow(freedb).to receive(:get)
+      allow(freedb).to receive(:status).and_return 'ok'
+      main.get
+      expect(main.musicbrainz_failed).to eq(true)
+    end
+
+    it "should be false if musicbrainz is the preference and it returns multipleRecords" do
+      allow(prefs).to receive(:metadataProvider).and_return("musicbrainz")
+      expect(musicbrainz).to receive(:get)
+      expect(musicbrainz).to receive(:status).and_return 'multipleRecords'
+      main.get
+      expect(main.musicbrainz_failed).to eq(false)
+    end
+
+    it "should be true if gnudb fails and musicbrainz fallback also fails" do
+      allow(prefs).to receive(:metadataProvider).and_return("gnudb")
+      expect(freedb).to receive(:get)
+      expect(freedb).to receive(:status).and_return 'mayday'
+      expect(musicbrainz).to receive(:get)
+      expect(musicbrainz).to receive(:status).and_return 'noMatches'
+      main.get
+      expect(main.musicbrainz_failed).to eq(true)
+    end
+
+    it "should be false if gnudb succeeds (musicbrainz never tried)" do
+      allow(prefs).to receive(:metadataProvider).and_return("gnudb")
+      expect(freedb).to receive(:get)
+      expect(freedb).to receive(:status).and_return 'ok'
+      main.get
+      expect(main.musicbrainz_failed).to eq(false)
+    end
+
+    it "should be false if provider is none" do
+      allow(prefs).to receive(:metadataProvider).and_return("none")
+      main.get
+      expect(main.musicbrainz_failed).to eq(false)
     end
   end
 end


### PR DESCRIPTION
## Summary

The MusicBrainz submit URL was displayed unconditionally for every recognized disc. Now it only appears when `musicbrainz_failed` is true:
- `metadataProvider` is set to `musicbrainz`
- MusicBrainz lookup returned `noMatches` or a network error occurred

## Changes

- `Metadata::Main`: added `musicbrainz_failed` attribute. Set to `true` when MusicBrainz was tried and returned `noMatches` (or network error)
- `Disc`: captures the value in `setMetadata` and exposes it via `attr_reader`
- `CliDisc#showMusicbrainzIDSubmitInfo`: changed condition from `discReady?` to `discReady? && @cd.musicbrainz_failed`

## Behaviour

| Setting | MusicBrainz result | URL shown |
|---------|-------------------|-----------|
| `musicbrainz` | `ok` | no |
| `musicbrainz` | `multipleRecords` | no |
| `musicbrainz` | `noMatches` or network error | **yes** |
| `gnudb` | any | no |
| `none` | any | no |

## Tests

- `spec/metadata/main_spec.rb`: 6 new test cases
- `spec/disc/disc_spec.rb`: 2 new test cases
- All 27 affected tests pass